### PR TITLE
feat: use title for breadcrumbs with alternative "Home" text

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,7 @@ plugins:
       additional_index_folders:
         - temp_dir
       generate_home_index: false
+      use_page_titles: true # use page title instead of path in breadcrumbs
+      home_text: "Home"
 ```
 


### PR DESCRIPTION
Fixes #3 

* Adds `use_page_titles` to use page title instead of path in breadcrumbs
* Adds `home_text` option as a substitute for the root nav breadcrumb (⌂ / 🏠, etc)

(PR generated by Copilot in GH UI -- not tested)